### PR TITLE
Add missing JUKEBOX_PLAYER

### DIFF
--- a/eo_protocol.txt
+++ b/eo_protocol.txt
@@ -2105,6 +2105,12 @@ server_packet(Jukebox, Msg)
 	char note_id
 }
 
+"Play background music"
+server_packet(Jukebox, Player)
+{
+        char mfx_id
+}
+
 
 // --- Warp
 


### PR DESCRIPTION
Packet is used for setting background music during weddings