### PR TITLE
Change `drop_item` field to `ShortItem` in `ITEM_DROP`

### DIFF
--- a/eo.txt
+++ b/eo.txt
@@ -1859,8 +1859,7 @@ client_packet(Item, Use)
 "Dropping items on the ground"
 client_packet(Item, Drop)
 {
-	// Official EO sends either 3 or 4 bytes for drop_item.amount
-	struct Item drop_item
+	struct ShortItem drop_item
 	struct Coords coords
 }
 


### PR DESCRIPTION
The official game client will send a 3-byte drop amount up to a value of
16194277. It will send a 4-byte drop amount for values above this threshold, which is a bug in the way the the EO game client encodes numbers.
EOSERV tries to handle this in a hacky way.
The official EO game server does not, so the definition of the protocol probably shouldn't either.